### PR TITLE
Implement withContext, getContext, Context.as

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Consolidating all service injection into a single context parameter makes it eas
 
 *In production code*
 ```ts
+import { Context, withContext, getContext } from '@sabl/context';
+
 /* -- service startup -- */
 const app = new [express | koa | etc.]();
  
@@ -108,8 +110,7 @@ const ctx = Context.background.
 
 // Attach context to each incoming request
 app.use((req, res, next) => {
-  req.context = ctx;
-  return next(req, res);
+  return next(withContext(req, ctx), res);
 })
 
 /* -- export data route -- */ 
@@ -117,8 +118,9 @@ import { exportData } from '$/export-service'
 
 app.use('data/export', async (req, res) => { 
   const exportParams = parseBody(req.body);
+  const ctx = getContext(req);
   // Pass along context to service logic
-  const data = await exportData(req.context, exportParams);
+  const data = await exportData(ctx, exportParams);
   res.json(data);
 })
 ```

--- a/docs/DOCS.md
+++ b/docs/DOCS.md
@@ -3,14 +3,16 @@
 ## Contents
 
 - [Basic API](#basic-api)
-  - [Core interfaces](#icontext-interface)
+  - [Core interfaces](#core-interfaces-icontext-canceler)
   - [Callback types](#callback-types)
     - [`CancelFunc`](#cancelfunc)
     - [`ContextGetter<T>`](#contextgettert)
     - [`ContextSetter<T>`](#contextsettert)
   - [Static package functions](#static-package-functions)
-    - [`withValue`](#value-context)
-    - [`withCancel`](#cancelable-context)
+    - [`withValue`](#withvalue)
+    - [`withCancel`](#withcancel)
+    - [`withContext`](#withcontext)
+    - [`getContext`](#getcontext)
 - [Immutability](#immutability)
   - [Overriding values](#overriding-values)
   - [Cascading cancellations](#cascading-cancellations)
@@ -83,22 +85,78 @@ A context setter function does not accept a key value. Instead, it encapsulates 
 
 ### `withValue`
 
-Returns a child context with a value set. Note this function accepts any value that implements the minimal [`IContext` interface](#icontext-interface) but it returns a concrete [`Context`](#extended-context-interface).
-
 ```ts
 export function withValue(
   parent: IContext, 
   key: symbol | string, 
   value: unknown
-): Context { ... }
+): Context;
 ```
+
+Returns a child context with a value set. Note this function accepts any value that implements the minimal [`IContext` interface](#icontext-interface) but it returns a concrete [`Context`](#extended-context-interface).
 
 ### `withCancel`
 
+```ts
+export function withCancel(parent: IContext): [Context, CancelFunc];
+```
+
 Returns a child cancelable context along with a function the can be called to cancel it. Note this function accepts any value that implements the minimal [`IContext` interface](#icontext-interface) but returns a concrete [`Context`](#extended-context-interface).
 
+### `withContext`
+
 ```ts
-export function withCancel(parent: IContext): [Context, CancelFunc] { ... }
+export function withContext<T>(source: T, ctx: IContext): T;
+```
+
+Returns a proxy of the `source` object with the provided context attached. The context can be retrieved from the proxy object using [`getContext`](#getcontext).
+
+### `getContext`
+
+```ts
+export function getContext(
+  source: unknown, 
+  allowNull: boolean = false
+): Context;
+```
+
+Retrieves a context from a proxy object previously created with [`withContext`](#withcontext). Returns a concrete [`Context`](#context-class) even if the original context provided to `getContext` was not, by internally using [`Context.as`](#as). Will throw an error if no context is present, unless `allowNull` is true.
+
+#### Using `withContext` and `getContext`
+
+`withContext` and `getContext` are useful for integrating the context pattern into an existing codebase where it is not possible or practical to change the signatures of many existing functions are APIs. A prime use case is to incorporate the context pattern into existing service middleware patterns such as those used by express. The following example adds a very simple inline middleware to attach a root context to each request. That context can then be retrieved and used in any downstream middleware or endpoint.
+
+```ts
+import { Context, withContext, getContext } from '@sabl/context';
+
+/* -- service startup -- */
+const app = new [express | koa | etc.]();
+ 
+// Build up shared services to inject
+const ctx = Context.background.
+  withValue(withRepo, new RealRepo()).
+  withValue(withLogger, new RealLogger()).
+  withValue(with..., new ...()) 
+  /* etc */; 
+
+// Attach root context to each incoming request
+app.use((req, res, next) => {
+  return next(withContext(req, ctx), res);
+})
+
+/* -- in other middleware -- */
+async function authorizeMiddleware(req, res, next) {
+  const ctx = getContext(req);
+  // Now retrieve dependencies, etc.
+  const secSvc = ctx.require(getSecSvc);
+}
+
+/* -- in an endpoint -- */
+async function getItems(req, res) {
+  const ctx = getContext(req);
+  // Now retrieve validated state, etc.
+  const [user, order] = ctx.require(getUser, getOrder);
+}
 ```
 
 ## Immutability
@@ -138,22 +196,22 @@ This library defines `Context` as a concrete class which implements `IContext` b
 ```ts
 class Context implements IContext {
   // Base IContext interface:
-  value(key: Symbol | string): unknown { ... }
-  get canceler(): Canceler | null { ... }
-  get canceled(): boolean { ... }
+  value(key: Symbol | string): unknown;
+  get canceler(): Canceler | null;
+  get canceled(): boolean;
 
   // =============================================
   //  Convenience instance methods
   // =============================================
 
   /** Create a child context with the provided key and value */
-  withValue(key: symbol | string, value: unknown): Context { ... }
+  withValue(key: symbol | string, value: unknown): Context;
 
   /** Create a new child context using the provided setter and value */
-  withValue<T>(setter: ContextSetter<T>, item: T): Context { ... }
+  withValue<T>(setter: ContextSetter<T>, item: T): Context;
 
   /** Create a child cancelable context */
-  withCancel(): Context { ... }
+  withCancel(): Context;
 
   /** Require one to six context items using their getter functions, 
    * throwing an error if any is null or undefined */
@@ -170,19 +228,22 @@ class Context implements IContext {
   // =============================================
 
   /** Get a simple root context */
-  static get background(): Context { ... }
+  static get background(): Context;
+
+  /** Wrap an IContext as a concrete Context */
+  static as(source: IContext): Context;
 
   /** Create a new root empty context with a name */
-  static empty(name: string): Context { ... }
+  static empty(name: string): Context;
 
   /** Create a new root context with a value */
-  static value(key: symbol | string, value: unknown): Context { ... }
+  static value(key: symbol | string, value: unknown): Context;
 
   /** Create a new root context using the provided setter and value */
-  static value<T>(setter: ContextSetter<T>, value: T): Context { ... }
+  static value<T>(setter: ContextSetter<T>, value: T): Context;
    
   /** Create a new root cancelable context */
-  static cancel(): [Context, CancelFunc] { ... }
+  static cancel(): [Context, CancelFunc];
 }
 ```
 
@@ -244,6 +305,9 @@ The `Context` class includes several factory members for retrieving or creating 
 
 #### `background`
 `Context.background` is an empty base context that can be used as a root context.
+
+#### `as`
+`Context.as` is a convenient way to accept any `IContext` (interface) value but convert it to a concrete `Context` in order to use the instance methods `withValue`, `withCancel`, and `require`. If the input value is already a `Context` instance then that value is returned. If it is not, a new `Context` instance which wraps the provided value is returned.
 
 #### `empty`
 `Context.empty` creates an empty root context with a custom name. The name of the context has no effect whatsoever except in the output of `toString`:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sabl/context",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "JavaScript / TypeScript implementation of sabl/context pattern",
   "scripts": {
     "build": "tsc --build tsconfig.build.json",

--- a/src/context.ts
+++ b/src/context.ts
@@ -215,6 +215,16 @@ export class Context {
     return this.#background;
   }
 
+  /**
+   * Returns a concrete {@link Context} from the
+   * source interface. If `source` is already a
+   * Context instance then it is returned.
+   */
+  static as(source: IContext): Context {
+    if (source instanceof Context) return source;
+    return new Context(source);
+  }
+
   /** Create a new empty root context */
   static empty(name?: string): Context {
     return new Context(null, name);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@
 
 export { IContext, Context, withValue, withCancel } from './context';
 export { CancelFunc, Canceler } from './canceler';
+export { withContext, getContext } from './proxy';

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,40 @@
+// Copyright 2022 Joshua Honig. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+import { Context, IContext } from './context';
+
+const attachedContext = Symbol('context');
+
+/**
+ * Proxy an input source while attaching a context to it which can be
+ * retrieved using {@link getContext}
+ * @param source The object to which the context should be attached
+ * @param ctx The context to attach
+ * @returns A proxy of `source`
+ */
+export function withContext<T extends object>(source: T, ctx: IContext): T {
+  return new Proxy(source, {
+    get: function (target, p, receiver) {
+      if (p === attachedContext) {
+        return ctx;
+      }
+      return Reflect.get(target, p, receiver);
+    },
+  });
+}
+
+/**
+ * Retrieve the context previously attached to an object using {@link withContext}
+ * @param source The object to which the context should be attached
+ * @param allowNull Whether to ignore if no context was present
+ * @returns The retrieved context
+ */
+export function getContext(source: unknown, allowNull = false): Context {
+  const ctx = (<{ [attachedContext]: IContext }>source)[attachedContext];
+  if (!allowNull && ctx == null) {
+    throw new Error('Context not assigned to source');
+  }
+  if (ctx == null) return ctx;
+  return Context.as(ctx);
+}

--- a/test/context/factories.spec.ts
+++ b/test/context/factories.spec.ts
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 import { Context, IContext, withValue } from '$';
+import { CustomRootContext } from '$test/fixtures/custom-context';
 
 describe('background', () => {
   it('returns a background context', () => {
@@ -20,6 +21,21 @@ describe('background', () => {
     for (let i = 0; i < 10; i++) {
       expect(Context.background).toBe(bg);
     }
+  });
+});
+
+describe('as', () => {
+  it('returns existing context', function () {
+    const source = Context.empty('hello');
+    const ctx = Context.as(source);
+    expect(ctx).toBe(source);
+  });
+
+  it('wraps a context interface', function () {
+    const source = new CustomRootContext('a', 1);
+    const ctx = Context.as(source);
+    expect(ctx).not.toBe(source);
+    expect(ctx).toBeInstanceOf(Context);
   });
 });
 

--- a/test/context/proxy.spec.ts
+++ b/test/context/proxy.spec.ts
@@ -1,0 +1,38 @@
+// Copyright 2022 Joshua Honig. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+import { Context, withContext, getContext } from '$';
+
+describe('context proxy', function () {
+  it('sets and gets context', function () {
+    const source = global.performance;
+    const ctx = Context.background.withValue('a', 1);
+    const proxy = withContext(source, ctx);
+
+    // Ensure proxy behaves like source
+    expect(proxy).toBeInstanceOf(source.constructor);
+    expect(proxy.toJSON().nodeTiming.name).toEqual(
+      source.toJSON().nodeTiming.name
+    );
+
+    // Can retrieve context
+    const ctx2 = getContext(proxy);
+    expect(ctx2).toBe(ctx);
+    expect(ctx.value('a')).toBe(1);
+  });
+
+  describe('getContext', function () {
+    it('throws error if no context present', function () {
+      expect(() => getContext(new Date())).toThrow(
+        'Context not assigned to source'
+      );
+    });
+
+    it('returns null if allowNull is true', function () {
+      let ctx = null;
+      expect(() => (ctx = getContext(new Date(), true))).not.toThrow();
+      expect(ctx).toBe(undefined);
+    });
+  });
+});


### PR DESCRIPTION
Implements withContext and getContext as well as context.as in order to better support integrating the context pattern into existing codebases and frameworks. Includes update docs.