### PR TITLE
feat: ensure child cancellations are unregistered

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 [![codecov](https://codecov.io/gh/libsabl/context-js/branch/main/graph/badge.svg?token=TVL1XYSJHA)](https://app.codecov.io/gh/libsabl/context-js/branch/main)
 <!-- END:REMOVE_FOR_NPM -->
 
-# sabl/js/context
+# @sabl/context
+ 
+**context** is a pattern for injecting state and dependencies and for propagating cancellation signals. It is simple, mechanically clear, and intrinsically safe for concurrent environments. It was first demonstrated in the [golang](https://go.dev/doc/) standard library [`context` package](https://pkg.go.dev/context). This package makes the same pattern available in TypeScript and JavaScript projects.
 
-[**sabl**](https://github.com/libsabl) is an open-source project to identify, describe, and implement effective software component patterns which solve small problems clearly, can be composed to solve big problems, and which work consistently across many programming langauges.
+For more detail on the context pattern, see sabl / [patterns](https://github.com/libsabl/patterns#patterns) / [context](https://github.com/libsabl/patterns/blob/main/patterns/context.md).
 
-**context** is a sabl root pattern that provides a solution for state injection that is simple, extensible, and intrinsicly thread safe. It was first demonstrated in the golang [`context` package](https://pkg.go.dev/context) which is now part of the [**go**](https://go.dev/doc/) standard library.
 <!-- BEGIN:REMOVE_FOR_NPM -->
+> [**sabl**](https://github.com/libsabl/patterns) is an open-source project to identify, describe, and implement effective software patterns which solve small problems clearly, can be composed to solve big problems, and which work consistently across many programming languages.
 
 ## Full Docs
 
@@ -22,7 +24,7 @@ See [SETUP.md](./docs/SETUP.md), [CONFIG.md](./docs/CONFIG.md).
 
 1. Define a getter and setter
 
-   You can also use plain strings or public symbol keys with `withValue` and `value`, but using the following pattern is much better for both runtime and compile type safety:
+   You can use plain strings or public symbol keys with `withValue` and `value`, but using the following pattern is much better for both runtime and compile type safety:
 
    ```ts
    import { Maybe, IContext, Context, withValue } from '@sabl/context';

--- a/build/publish.js
+++ b/build/publish.js
@@ -52,7 +52,7 @@ async function addReadmeHeaders(source, pkgv) {
     md += ' | **tag**: ['`v${pkgv}``](${ghRelease}) `;
   }
   md += ' | **commit**: [`' + commit.substring(0, 9) + '`](' + ghBrowse + ')';
-  md += ' | [**Full docs**](' + docsPath + ')';
+  md += ' | See [**Full docs on GitHub**](' + docsPath + ')';
   return md + EOL + source;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sabl/context",
-  "version": "0.2.0-a005",
+  "version": "0.3.0",
   "description": "JavaScript / TypeScript implementation of sabl/context pattern",
   "scripts": {
     "build": "tsc --build tsconfig.build.json",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sabl/context",
-  "version": "0.2.0-a004",
+  "version": "0.2.0-a005",
   "description": "JavaScript / TypeScript implementation of sabl/context pattern",
   "scripts": {
     "build": "tsc --build tsconfig.build.json",

--- a/test/context/cancel.spec.ts
+++ b/test/context/cancel.spec.ts
@@ -6,6 +6,7 @@
 
 import { Canceler, Context } from '$';
 import { VoidCallback } from '$/canceler';
+import exp from 'constants';
 
 describe('cancel', () => {
   it('creates a root cancelable context', () => {
@@ -51,6 +52,22 @@ describe('cancel', () => {
 
     // Prove child callbacks were called
     expect(somevar).toBe(3);
+  });
+
+  it('removes itself from parent cancelers', () => {
+    const [ctxParent] = Context.cancel();
+    const [ctxChild, cancelChild] = ctxParent.withCancel();
+
+    expect(Canceler.size(ctxParent.canceler)).toBe(1);
+
+    // Cancel the child directly
+    cancelChild();
+    expect(ctxChild.canceled).toBe(true);
+
+    // Parent should not be canceled, but
+    // callback should be removed from parent canceler
+    expect(ctxParent.canceled).toBe(false);
+    expect(Canceler.size(ctxParent.canceler)).toBe(0);
   });
 });
 


### PR DESCRIPTION
- Ensures cascading cancellations are cleaned up when child is canceled
- Add docs to highlight importance of canceling all contexts